### PR TITLE
langPicker icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The following attributes are set within *config.json*.
 
 >**_showOnCourseLoad** (boolean): Determines whether the language picker will be displayed on course load. If set to false, the course will load with the default language selected and the user will need to use the icon in the navigation bar to change languages.
 
+>**_languagePickerIconClass** (string): The class defined here will define the icon of the language-picker in the navigation bar. The vanilla theme supports the following class-names by default: "icon-globe", "icon-language-1", "icon-language-2". The default value for this attribute is "icon-language-2".    
+
 >**_languages** (object):  The languages attribute group contains properties related to the available languages.   It contains values for **_language**, **_direction**, **displayName**, **warningTitle**, **warningMessage**, and **_buttons**.  
 
 >>**_language** (string): This text must match the name of the language-specific folder located in the course root, for example, "en" from *course/en*. It is used as the value for the HTML `lang` attribute. It is highly recommended that codes for web languages be used. Reference a source such as the [IANA Language Subtag Registry](http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry). 

--- a/example.json
+++ b/example.json
@@ -6,6 +6,8 @@
     "displayTitle": "Please select a language",
     "body": "This course is available in the following languages:",
     "_showOnCourseLoad": true,
+    "_comment": "default class names are: icon-globe, icon-language-1, icon-language-2",
+    "_languagePickerIconClass": "icon-language-2",
     "_languages": [
         {
             "_language": "en",

--- a/js/languagePickerNavView.js
+++ b/js/languagePickerNavView.js
@@ -8,7 +8,16 @@ define([
         
         tagName: 'button',
         
-        className: 'languagepicker-icon base icon icon-language',
+        className: function () {
+            var classNames = 'languagepicker-icon base icon';
+            var customClass = 'icon-language-2';
+
+            if (this.model.has('_languagePickerIconClass') && this.model.get('_languagePickerIconClass') !== '') {
+                customClass = this.model.get('_languagePickerIconClass');
+            }
+
+            return classNames + ' ' + customClass;
+        },
         
         events: {
             'click': 'onClick'

--- a/js/languagePickerNavView.js
+++ b/js/languagePickerNavView.js
@@ -10,11 +10,7 @@ define([
         
         className: function () {
             var classNames = 'languagepicker-icon base icon';
-            var customClass = 'icon-language-2';
-
-            if (this.model.has('_languagePickerIconClass') && this.model.get('_languagePickerIconClass') !== '') {
-                customClass = this.model.get('_languagePickerIconClass');
-            }
+            var customClass = this.model.get('_languagePickerIconClass') || 'icon-language-2';
 
             return classNames + ' ' + customClass;
         },

--- a/properties.schema
+++ b/properties.schema
@@ -63,6 +63,15 @@
                   "validators": [],
                   "help": "If set to 'false', language picker will not be displayed on course load"
                 },
+                "_languagePickerIconClass": {
+                  "type": "string",
+                  "required": false,
+                  "default": "icon-language-2",
+                  "title": "Class to customise Language Picker icon in the navbar.",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "Your default options here are: icon-globe, icon-language-1, icon-language-2"
+                },
                 "_languages": {
                   "type": "array",
                   "required": true,


### PR DESCRIPTION
allow customization of the icon used in the navigation bar
also 3 more icon alternatives are added to the core vanilla theme

fixes: #1275

in conjunction with: https://github.com/adaptlearning/adapt-contrib-vanilla/pull/198
