### PR TITLE
Resolves #1328, moves removal of 'in-languagepicker' class to remove()

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "name": "adapt-contrib-languagePicker",
     "repository": "git://github.com/adaptlearning/adapt-contrib-languagePicker.git",
     "framework": "^2.0.14",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "homepage": "https://github.com/adaptlearning/adapt-contrib-languagePicker",
     "issues": "https://github.com/adaptlearning/adapt_framework/issues",
     "displayName": "Language Picker",

--- a/js/languagePickerView.js
+++ b/js/languagePickerView.js
@@ -13,7 +13,7 @@ define([
         
         initialize: function () {
             this.initializeAccessibility();
-
+            $("html").addClass("in-languagepicker");
             this.listenTo(Adapt, 'remove', this.remove);
             this.render();
         },
@@ -39,10 +39,7 @@ define([
             this.model.setLanguage($(event.target).val());
         },
 
-
         initializeAccessibility: function() {
-            $("html").addClass("in-languagepicker");
-
             this.accessibilityView = new accessibilityView({
                 model:this.model
             });
@@ -52,9 +49,13 @@ define([
         },
 
         destroyAccessibility: function() {
+            this.accessibilityView.remove();
+        },
+
+        remove: function() {
             $("html").removeClass("in-languagepicker");
 
-            this.accessibilityView.remove();
+            Backbone.View.prototype.remove.apply(this, arguments);
         }
         
     }, {


### PR DESCRIPTION
Previously this class was being removed while the view was still on screen.

https://github.com/adaptlearning/adapt_framework/issues/1326
