### PR TITLE
defensive programming around use of navigationBarLabel property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "name": "adapt-contrib-languagePicker",
     "repository": "git://github.com/adaptlearning/adapt-contrib-languagePicker.git",
     "framework": "^2.0.14",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "homepage": "https://github.com/adaptlearning/adapt-contrib-languagePicker",
     "issues": "https://github.com/adaptlearning/adapt_framework/issues",
     "displayName": "Language Picker",

--- a/js/adapt-languagePicker.js
+++ b/js/adapt-languagePicker.js
@@ -61,7 +61,7 @@ define([
     
     function setupNavigationView () {
         var courseGlobals = Adapt.course.get('_globals')._extensions;
-        var navigationBarLabel = 'Select course language';
+        var navigationBarLabel = '';
         if (_.has(courseGlobals, '_languagePicker')) {
             navigationBarLabel = courseGlobals._languagePicker.navigationBarLabel;
         }

--- a/js/adapt-languagePicker.js
+++ b/js/adapt-languagePicker.js
@@ -62,7 +62,7 @@ define([
     function setupNavigationView () {
         var courseGlobals = Adapt.course.get('_globals')._extensions;
         var navigationBarLabel = '';
-        if (_.has(courseGlobals, '_languagePicker')) {
+        if (courseGlobals._languagePicker) {
             navigationBarLabel = courseGlobals._languagePicker.navigationBarLabel;
         }
 

--- a/js/adapt-languagePicker.js
+++ b/js/adapt-languagePicker.js
@@ -60,6 +60,10 @@ define([
     }
     
     function setupNavigationView () {
+        /* 
+         * On the framework this isn't an issue, but courses built in the authoring tool before the ARIA label 
+         * was added will break unless the extension is removed then added again.
+         */
         var courseGlobals = Adapt.course.get('_globals')._extensions;
         var navigationBarLabel = '';
         if (courseGlobals._languagePicker) {

--- a/js/adapt-languagePicker.js
+++ b/js/adapt-languagePicker.js
@@ -60,10 +60,16 @@ define([
     }
     
     function setupNavigationView () {
+        var courseGlobals = Adapt.course.get('_globals')._extensions;
+        var navigationBarLabel = 'Select course language';
+        if (_.has(courseGlobals, '_languagePicker')) {
+            navigationBarLabel = courseGlobals._languagePicker.navigationBarLabel;
+        }
+
         var languagePickerNavView = new LanguagePickerNavView({
             model: languagePickerModel,
             attributes:  {
-                "aria-label": Adapt.course.get('_globals')._extensions._languagePicker.navigationBarLabel
+                "aria-label": navigationBarLabel
             }
         });
         


### PR DESCRIPTION
Fixes issue with infinite loading spinner when `navigationBarLabel` global property isn't set