### PR TITLE
stop displayName from being escaped

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The following attributes are set within *config.json*.
 As well as requiring [**Adapt Framework**](https://github.com/adaptlearning/adapt_framework) v2.0.14 (or better) you will need v2.0.4 (or better) of the [**Vanilla theme**](https://github.com/adaptlearning/adapt-contrib-vanilla) and, if you need your course to be SCORM conformant, v2.0.13 (or better) of the [**Spoor**](https://github.com/adaptlearning/adapt-contrib-spoor) extension.
 
 ----------------------------
-**Version number:**  1.0.6  <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  1.0.7  <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:**  2.0.14+     
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-bookmarking/graphs/contributors)    
 **Accessibility support:** WAI AA   

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "name": "adapt-contrib-languagePicker",
     "repository": "git://github.com/adaptlearning/adapt-contrib-languagePicker.git",
     "framework": ">=2.0.14",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "homepage": "https://github.com/adaptlearning/adapt-contrib-languagePicker",
     "issues": "https://github.com/adaptlearning/adapt_framework/issues",
     "displayName": "Language Picker",

--- a/templates/languagePickerDrawerView.hbs
+++ b/templates/languagePickerDrawerView.hbs
@@ -2,7 +2,7 @@
   <div class="languagepicker-inner">
      {{#each _languages}}
         <div class="languagepicker-language drawer-item {{#if _isSelected}}selected{{/if}} {{_language}} {{#equals _direction "rtl"}}dir-rtl{{/equals}}">
-          <button class="base drawer-item-open" data-language="{{_language}}" {{#if _isSelected}}disabled{{/if}}>{{displayName}}</button>
+          <button class="base drawer-item-open" data-language="{{_language}}" {{#if _isSelected}}disabled{{/if}}>{{{displayName}}}</button>
         </div>
      {{/each}}
   </div>

--- a/templates/languagePickerDrawerView.hbs
+++ b/templates/languagePickerDrawerView.hbs
@@ -1,8 +1,10 @@
+{{! make the _globals object in course.json available to this template}}
+{{import_globals}}
 <div class="languagepicker">
   <div class="languagepicker-inner">
      {{#each _languages}}
         <div class="languagepicker-language drawer-item {{#if _isSelected}}selected{{/if}} {{_language}} {{#equals _direction "rtl"}}dir-rtl{{/equals}}">
-          <button class="base drawer-item-open" data-language="{{_language}}" {{#if _isSelected}}disabled{{/if}}>{{{displayName}}}</button>
+          <button class="base drawer-item-open" data-language="{{_language}}" {{#if _isSelected}}disabled{{/if}}>{{{compile displayName}}}</button>
         </div>
      {{/each}}
   </div>

--- a/templates/languagePickerView.hbs
+++ b/templates/languagePickerView.hbs
@@ -1,18 +1,20 @@
+{{! make the _globals object in course.json available to this template}}
+{{import_globals}}
 <div class="languagepicker-inner">
     <div class="languagepicker-title">
         <div class="languagepicker-title-inner" role="heading" tabindex="0">
-            {{{ displayTitle }}}
+            {{{compile displayTitle }}}
         </div>
     </div>
     <div class="languagepicker-body">
         <div class="languagepicker-body-inner">
-            {{{a11y_text body }}}
+            {{{compile_a11y_text body }}}
         </div>
     </div>
     <div class="languagepicker-languages">
         {{#each _languages}}
             <button class="languagepicker-language {{_language}}" value="{{_language}}">
-                {{{ displayName }}}
+                {{{compile displayName }}}
             </button>
         {{/each}}
     </div>


### PR DESCRIPTION
allows you to include HTML entities within `displayName`, particularly useful if you need to include an RTL or LTR mark (`&rlm;` or `&lrm;`)

Fixes https://github.com/adaptlearning/adapt_framework/issues/1856