### PR TITLE
remove import_globals from languagePickerView.hbs

### DIFF
--- a/templates/languagePickerView.hbs
+++ b/templates/languagePickerView.hbs
@@ -1,5 +1,3 @@
-{{! make the _globals object in course.json available to this template}}
-{{import_globals}}
 <div class="languagepicker-inner">
     <div class="languagepicker-title">
         <div class="languagepicker-title-inner" role="heading" tabindex="0">


### PR DESCRIPTION
as there's no _globals to import at the point this template is rendered... fixes https://github.com/adaptlearning/adapt_framework/issues/1908