### PR TITLE
amend to _.defer call in restoreLocation so that there's no loss of scope

### DIFF
--- a/js/languagePickerModel.js
+++ b/js/languagePickerModel.js
@@ -56,7 +56,9 @@ define([
 
         restoreLocation: function() {
             if (!Adapt.mapById(this.locationId)) return;
-            _.defer(Adapt.navigateToElement, '.' + this.locationId);
+            _.defer(function() {
+                Adapt.navigateToElement('.' + this.locationId);
+            }.bind(this));
         },
 
         /**


### PR DESCRIPTION
when `Adapt.navigateToElement` is called

fixes https://github.com/adaptlearning/adapt_framework/issues/2457