### PR TITLE
Pick up on _activeLanguage config setting to bypass the picker screen

### DIFF
--- a/js/adapt-languagePicker.js
+++ b/js/adapt-languagePicker.js
@@ -45,6 +45,11 @@ define([
       return;
     }
 
+    if (Adapt.config.get('_activeLanguage')) {
+      languagePickerModel.setLanguage(Adapt.config.get('_activeLanguage'));
+      return;
+    }
+
     if (languagePickerModel.get('_showOnCourseLoad') === false) {
       languagePickerModel.setLanguage(Adapt.config.get('_defaultLanguage'));
       return;


### PR DESCRIPTION
For issue [#3218](https://github.com/adaptlearning/adapt_framework/issues/3218)