### PR TITLE
issue/60 Added wait queue after offlineStorage:ready

### DIFF
--- a/js/adapt-languagePicker.js
+++ b/js/adapt-languagePicker.js
@@ -45,6 +45,7 @@ class LanguagePicker extends Backbone.Controller {
    * If it was, load it. If it wasn't, show the language picker
    */
   onOfflineStorageReady() {
+    await Adapt.wait.queue();
     const storedLanguage = offlineStorage.get('lang');
 
     if (storedLanguage) {


### PR DESCRIPTION
fixes #60 

### Added
* A wait queue after `offlineStorage:ready` is triggered to allow other plugins to interject in the loading process