### PR TITLE
Update: Changed to use `@max-content-width` variable (fixes #75)

### DIFF
--- a/less/languagePicker.less
+++ b/less/languagePicker.less
@@ -2,7 +2,7 @@
 // --------------------------------------------------
 .languagepicker {
   &__inner {
-    .l-container-responsive(@device-width-large);
+    .l-container-responsive(@max-content-width);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "git://github.com/adaptlearning/adapt-contrib-languagePicker.git"
   },
   "version": "5.1.1",
-  "framework": ">=5.19.1",
+  "framework": ">=5.24.2",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-languagePicker",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-languagePicker/issues",
   "extension": "languagePicker",


### PR DESCRIPTION
Fixes: #75 

### Update
* Changed `@device-width-large` to `@max-content-width`

Dependencies
* Core [pull 275](https://github.com/adaptlearning/adapt-contrib-core/pull/275)
* Vanilla [pull 380](https://github.com/adaptlearning/adapt-contrib-vanilla/pull/380)
* BoxMenu [pull 131](https://github.com/adaptlearning/adapt-contrib-boxMenu/pull/131)
