### PR TITLE
Fix: Retain location before language change

### DIFF
--- a/js/languagePickerModel.js
+++ b/js/languagePickerModel.js
@@ -38,6 +38,7 @@ export default class LanguagePickerModel extends Backbone.Model {
   }
 
   setLanguage(language, { canReset = true } = {}) {
+    this.locationId = offlineStorage.get('location') || null;
     Adapt.config.set({
       _activeLanguage: language,
       _defaultDirection: this.getLanguageDetails(language)._direction

--- a/js/languagePickerModel.js
+++ b/js/languagePickerModel.js
@@ -52,6 +52,7 @@ export default class LanguagePickerModel extends Backbone.Model {
     if (!shouldReset || !hasOfflineStorageClear) return;
     // New reset functionality
     offlineStorage.clear();
+    this.locationId = null;
   }
 
   markLanguageAsSelected(model, language) {


### PR DESCRIPTION
fixes #82 
fixes #70 

### Fix
* Retain location before language change in order to restore the current location on reload

