### PR TITLE
Update: remove legacy nav btn float (fixes #93)

### DIFF
--- a/less/languagePicker.less
+++ b/less/languagePicker.less
@@ -14,14 +14,6 @@
   }
 }
 
-// Nav button styling
-// --------------------------------------------------
-.nav {
-  &__languagepicker-btn {
-    .u-float-right;
-  }
-}
-
 // Notify direction amends
 // --------------------------------------------------
 .notify {


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-languagePicker/issues/93

### Update
The nav button [float](https://github.com/adaptlearning/adapt-contrib-languagePicker/blob/182b4c996396ca9897a1e4273f7e4541eeb1b7af/less/languagePicker.less#L21) style is no longer required since the plugin was updated to support [`data-order`](https://github.com/adaptlearning/adapt-contrib-languagePicker/pull/89).

Core also [overrides](https://github.com/adaptlearning/adapt-contrib-core/blob/8b36e3ee68941b62e711198f49fa9345c1758132/less/core/nav.less#L38) any `.nav__btn` `float` styles. 


