### PR TITLE
Update: Allow Drawer item text alignment to inherit from course language (fixes #107)

### DIFF
--- a/less/languagePicker.less
+++ b/less/languagePicker.less
@@ -6,14 +6,6 @@
   }
 }
 
-// Language Picker drawer
-// --------------------------------------------------
-.languagepicker-drawer {
-  &__item.is-rtl {
-    direction: rtl;
-  }
-}
-
 // Notify direction amends
 // --------------------------------------------------
 .notify {


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-languagePicker/issues/107

### Update
* Drawer item text alignment should reflect the course language rather than the text direction of the language option. For example, we don't left align LTR language options when a course is presented in RTL languages.

As discussed in the issue, it seems common practice across the web to align language selection options with the site language. Regardless whether the language option is written in English or native language. Please refer to the [issue](https://github.com/adaptlearning/adapt-contrib-languagePicker/issues/107#issuecomment-2931894116) for examples.

The item `.is-rtl` selector still remains for those who want to override the language direction.

### Testing
1. Select a LTR language from the language drawer and note all drawer language options are left aligned.
2. Select a RTL language from the language drawer and note all drawer language options are right aligned.



