### PR TITLE
Update: remove header image aria-hidden (fixes #126)

### DIFF
--- a/templates/languagePickerView.hbs
+++ b/templates/languagePickerView.hbs
@@ -7,7 +7,7 @@
 
   {{#if _graphic.src}}
   <div class="languagepicker__image-container">
-    <img class="languagepicker__image" src={{_graphic.src}}{{#if _graphic.alt}} alt={{_graphic.alt}}{{else}} aria-hidden="true"{{/if}}  loading="eager" />
+    <img class="languagepicker__image" src="{{_graphic.src}}" alt="{{_graphic.alt}}" loading="eager" />
   </div>
   {{/if}}
 


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-languagePicker/issues/126

### Update
- remove image `aria-hidden` 
- add missing quotes to `src` and `alt` values

[Testing](https://github.com/adaptlearning/adapt-contrib-core/issues/822#issuecomment-3804968510) confirmed an empty alt tag (`alt=""`) is widely supported by screen readers / browsers to ignore an image without the need for `aria-hidden`.

This is part of a global change in Adapt to use `alt` instead of `aria-label` for image alternative text for consistency across Adapt and to align with best practice.

### Related
- Core image template and Notify popup - https://github.com/adaptlearning/adapt-contrib-core/pull/825)
- Boxmenu header image - https://github.com/adaptlearning/adapt-contrib-boxMenu/pull/231
- Hotgraphic main image - https://github.com/adaptlearning/adapt-contrib-hotgraphic/pull/357
- Tutor feedback image - https://github.com/adaptlearning/adapt-contrib-tutor/pull/123


